### PR TITLE
Strengthen Yoshitaka Inoue SEO and researcher entity signals

### DIFF
--- a/_includes/head/custom.html
+++ b/_includes/head/custom.html
@@ -22,10 +22,61 @@
 <meta name="msapplication-TileImage" content="{{ base_path }}/images/mstile-144x144.png?v=M44lzPylqQ">
 <meta name="msapplication-config" content="{{ base_path }}/images/browserconfig.xml?v=M44lzPylqQ">
 <meta name="theme-color" content="#ffffff">
+<meta name="author" content="Yoshitaka Inoue">
+<meta name="description" content="Yoshitaka Inoue is a machine learning researcher at the University of Minnesota and NIH working on AI for drug discovery, precision oncology, drug response prediction, graph learning, and biomedical reasoning.">
 <link rel="stylesheet" href="{{ base_path }}/assets/css/academicons.css"/>
 
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Person",
+  "@id": "https://inoue0426.github.io/#person",
+  "name": "Yoshitaka Inoue",
+  "url": "https://inoue0426.github.io/",
+  "image": "https://inoue0426.github.io/profile.png",
+  "jobTitle": "Machine Learning Researcher in AI for Drug Discovery",
+  "description": "Ph.D. candidate in Computer Science at the University of Minnesota and pre-doctoral fellow at the National Library of Medicine and National Cancer Institute, NIH, researching AI for drug discovery, precision oncology, and biomedical machine learning.",
+  "affiliation": [
+    {
+      "@type": "CollegeOrUniversity",
+      "name": "University of Minnesota"
+    },
+    {
+      "@type": "GovernmentOrganization",
+      "name": "National Institutes of Health"
+    },
+    {
+      "@type": "GovernmentOrganization",
+      "name": "National Library of Medicine"
+    },
+    {
+      "@type": "GovernmentOrganization",
+      "name": "National Cancer Institute"
+    }
+  ],
+  "alumniOf": {
+    "@type": "CollegeOrUniversity",
+    "name": "Nara Institute of Science and Technology"
+  },
+  "sameAs": [
+    "https://github.com/inoue0426",
+    "https://scholar.google.com/citations?user=aBizyLkAAAAJ",
+    "https://orcid.org/0000-0003-4432-8166",
+    "https://www.linkedin.com/in/inoue0426/"
+  ],
+  "knowsAbout": [
+    "Artificial intelligence for drug discovery",
+    "Biomedical machine learning",
+    "Drug response prediction",
+    "Graph representation learning",
+    "Precision oncology",
+    "Computational molecular medicine",
+    "Large language models for biomedical reasoning"
+  ]
+}
+</script>
 
-<!-- Support for MatJax -->
+<!-- Support for MathJax -->
 <script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 

--- a/_pages/about.md
+++ b/_pages/about.md
@@ -1,19 +1,31 @@
 ---
 permalink: /
-title: "About"
+title: "Yoshitaka Inoue | AI for Drug Discovery and Biomedical AI"
+excerpt: "Yoshitaka Inoue is a machine learning researcher at the University of Minnesota and NIH working on AI for drug discovery, precision oncology, drug response prediction, graph learning, and biomedical reasoning."
 author_profile: true
 redirect_from:
   - /about/
   - /about.html
 ---
 
-I am Yoshitaka Inoue, a Ph.D. candidate in Computer Science at the University of Minnesota, advised by Prof. Rui Kuang, and a pre-doctoral fellow at the National Library of Medicine / National Cancer Institute, co-advised by Dr. Augustin Luna.
+# Yoshitaka Inoue
 
-My research develops machine learning methods for molecular medicine, with a focus on drug response prediction, graph representation learning, perturbation modeling, and LLM-based biomedical reasoning for precision oncology.
+**Machine Learning Researcher in AI for Drug Discovery and Precision Oncology**
+
+I am **Yoshitaka Inoue**, a Ph.D. candidate in Computer Science at the **University of Minnesota**, advised by Prof. Rui Kuang, and a pre-doctoral fellow at the **National Library of Medicine / National Cancer Institute (NIH)**, co-advised by Dr. Augustin Luna.
+
+My research develops machine learning methods for molecular medicine, with a focus on **AI for drug discovery**, **drug response prediction**, **graph representation learning**, **perturbation modeling**, and **LLM-based biomedical reasoning** for precision oncology.
 
 I am currently seeking 2027 research internship opportunities and postdoctoral opportunities starting in September 2027.
 
 Previously, I received my M.Eng. in Information Science from the Nara Institute of Science and Technology and was a visiting scholar at the UC Davis Genome Center and DataLab.
+
+## Researcher Profiles
+
+- [Google Scholar](https://scholar.google.com/citations?user=aBizyLkAAAAJ)
+- [ORCID: 0000-0003-4432-8166](https://orcid.org/0000-0003-4432-8166)
+- [GitHub](https://github.com/inoue0426)
+- [LinkedIn](https://www.linkedin.com/in/inoue0426/)
 
 ## Recent News
 
@@ -25,11 +37,12 @@ Previously, I received my M.Eng. in Information Science from the Nara Institute 
 
 ## Research Interests
 
-- Machine learning for molecular medicine
+- Machine learning and artificial intelligence for drug discovery
 - Drug response prediction and treatment response modeling
 - Graph representation learning for biological and pharmacological data
 - Single-cell, perturbation, and intervention-aware representation learning
 - LLM-based biomedical reasoning and evidence integration
+- Precision oncology and computational molecular medicine
 
 ## Selected Publications
 


### PR DESCRIPTION
## Summary

This PR strengthens the site for searches around **Yoshitaka Inoue**, **AI for drug discovery**, and **biomedical machine learning**.

### Changes

- Rewrites the homepage title and summary around a clear researcher identity.
- Adds a visible `Yoshitaka Inoue` H1 and a concise professional descriptor.
- Adds consistent links to Google Scholar, ORCID, GitHub, and LinkedIn.
- Expands research-topic language without keyword stuffing.
- Adds `Person` JSON-LD structured data with affiliations, researcher profiles, and areas of expertise.
- Adds explicit author and description metadata.
- Fixes the `MatJax` typo in the custom-head comment.

## Expected impact

These changes should help search engines distinguish this Yoshitaka Inoue from same-name individuals and associate the site with University of Minnesota, NIH, AI for drug discovery, drug response prediction, graph learning, and precision oncology.

Search ranking changes are not immediate or guaranteed; recrawling and stronger external profile links are still required.